### PR TITLE
Fix string punctuation

### DIFF
--- a/index.less
+++ b/index.less
@@ -292,10 +292,20 @@
   }
 }
 
-.source.gfm .markup {
-  -webkit-font-smoothing: auto;
-  &.heading {
-    color: @red;
+.source.gfm {
+  .markup {
+    -webkit-font-smoothing: auto;
+    &.heading {
+      color: @red;
+    }
+
+    &.link {
+      color: @blue;
+    }
+  }
+
+  .link .entity {
+    color: @cyan;
   }
 }
 


### PR DESCRIPTION
Fixes the string punctuation not being highlighted, which ensures the empty string is colored. Also adds markdown link highlights.

![md-links](https://cloud.githubusercontent.com/assets/122102/3710223/1475c504-147b-11e4-9b10-520bfed61ef7.png)

@kevinsawicki 
