### PR TITLE
Improve coloring inside the classes and methods.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,9 +1,10 @@
 
-// Base16 Tomorrow light
+// Base16 Tomorrow Light
 
 @import (reference) "styles/syntax-variables";
 
 @import 'editor';
 @import 'language';
 
+@import 'languages/cs';
 @import 'languages/json';

--- a/styles/language.less
+++ b/styles/language.less
@@ -117,8 +117,16 @@
     }
   }
 
-  &.section.embedded {
-    color: @brown;
+  &.section {
+    &.embedded {
+      color: @brown;
+    }
+
+    &.method,
+    &.class,
+    &.inner-class {
+      color: @syntax-text-color;
+    }
   }
 }
 
@@ -166,10 +174,19 @@
 .meta {
   &.class {
     color: @yellow;
+
+    &.body {
+      color: @syntax-text-color;
+    }
   }
 
   &.link {
     color: @orange;
+  }
+
+  &.method-call,
+  &.method {
+    color: @syntax-text-color;
   }
 
   &.require {

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,5 @@
+.source.cs {
+  .keyword.operator {
+    color: @purple;
+  }
+}


### PR DESCRIPTION
This is the same as https://github.com/atom/base16-tomorrow-dark-theme/pull/30 for the light version.

- Fixed the coloring inside the methods, classes and inner classes.
- Added coloring for the keyword operator in C#.