### PR TITLE
Remove highlighting of links in comments

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -3,6 +3,10 @@
 
 .syntax--comment {
   color: @gray;
+
+  .syntax--markup.syntax--link {
+    color: @gray;
+  }
 }
 
 .syntax--entity {


### PR DESCRIPTION
Same as https://github.com/atom/base16-tomorrow-dark-theme/pull/39