### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/base16-tomorrow-light-theme), please direct all issues and pull requests there in the future!
+
+---
+
 # Base16 Tomorrow Light Syntax theme
 
 Atom theme using the ever popular [Base16 Tomorrow](http://chriskempson.github.io/base16/#tomorrow) light colors.


### PR DESCRIPTION
As of atom/atom#18180, the `base16-tomorrow-light-theme` package is now a part of the core Atom repository. This pull request updates `README.md` to reflect that fact. We'll be archiving this repository shortly.

/cc atom/atom#17837